### PR TITLE
P1/P2 only set flags for nightly.

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -49,7 +49,7 @@ let actions = [ // eslint-disable-line no-unused-vars
     events: {
       priority: ["P1"],
       flag: [
-        ["LATEST_FIREFOX_VERSION", "affected"],
+        ["FIREFOX_NIGHTLY", "affected"]
       ],
       status: ["NEW"],
     },
@@ -71,8 +71,7 @@ let actions = [ // eslint-disable-line no-unused-vars
     events: {
       priority: ["P2"],
       flag: [
-        ["LATEST_FIREFOX_VERSION", "wontfix"],
-        ["LATEST_FIREFOX_DEVEL_VERSION", "affected"]
+        ["FIREFOX_NIGHTLY", "fix-optional"]
       ],
       status: ["NEW"]
     },


### PR DESCRIPTION
From my understanding, P1 means that the bug should be fixed in the current train cycle, which at least means that nightly is affected, but does not imply anything on beta nor release versions.

As P2 implies that it should be fixed in the next cycle, this implies that nightly is affected, but that we are going to take patches if they are present, but we do not commit into making it for the current nightly cycle.

Is this a correct interpretation of P1 / P2?
