### PR TITLE
Prepend the action comment if there is already one.

### DIFF
--- a/content.js
+++ b/content.js
@@ -19,7 +19,8 @@ let eventFunctions = {
   comment: function(text) {
     log("inserting comment");
     let comment = document.getElementById("comment");
-    comment.value = text;
+    let oldText = comment.value || "";
+    comment.value = `${text}${oldText ? "\n\n" : ""}${oldText}`;
     comment.focus();
   },
   flag: function(version, status) {


### PR DESCRIPTION
Currently if there is already a comment, with some explanation on the triage decision, this text is going to be erased by the fact of processing the event.

This patch change this behaviour to always add the event-comment before of the hand-written comment.
