### PR TITLE
Do not override developer status.

### DIFF
--- a/content.js
+++ b/content.js
@@ -58,8 +58,19 @@ let eventFunctions = {
     let resolutionElement = document.getElementById("resolution");
     let duplicateElement = document.getElementById("dup_id");
 
-    statusElement.value = status;
-    statusElement.dispatchEvent(changeEvent);
+    // This ranking mechanism is used to avoid overriding fields which have
+    // already been refined by developers.
+    let statusRanks = {
+      "UNCONFIRMED": 0,
+      "NEW" : 1,
+      "ASSSIGNED" : 1,
+      "RESOLVED": 3
+    };
+
+    if (statusRanks[status] > statusRanks[statusElement.value]) {
+      statusElement.value = status;
+      statusElement.dispatchEvent(changeEvent);
+    }
 
     if (status === "RESOLVED") {
       resolutionElement.value = resolution;


### PR DESCRIPTION
This modification fixes #23, by ranking the status flag by order in which they are added by the user.
This changes implies that this tool cannot replace NEW by ASSIGNED, nor the opposite.
